### PR TITLE
Tracker messages

### DIFF
--- a/node.py
+++ b/node.py
@@ -12,8 +12,6 @@ from crypto.random_bytes import generate_bytes
 from crypto.rsa import rsa_decrypt
 
 
-# app = Flask(__name__)
-
 class Node(Flask):
     def __init__(self, name, ip, port):
         super().__init__(name)

--- a/tracker.py
+++ b/tracker.py
@@ -1,55 +1,119 @@
 import os
-from flask import Flask, render_template
-from flask import jsonify
-from common.network_info import *
+import requests
+from flask import Flask, render_template, jsonify, request
+from common.network_info import cid_size
+from crypto.random_bytes import generate_bytes
 
 
-app = Flask(__name__, template_folder=os.path.abspath('tracker/templates'))
+class Tracker(Flask):
+    def __init__(self):
+        super().__init__(__name__, template_folder=os.path.abspath('tracker/templates'))
 
-files = {"movie1": "cid1",
-         "movie2": "cid2",
-         "movie3": "cid3"}
+        self.files = {"movie1": "cid1",
+                 "movie2": "cid2",
+                 "movie3": "cid3"}
 
-peers = {"cid1": "IP1",
-         "cid2": "IP2"}
+        self.peers = {"cid1": "IP1",
+                 "cid2": "IP2"}
+
+        self.fsid_counter = 0
+
+    def handle_message(self, message):
+        # A new client connects to the network by sending the list of files
+        if message["payload"]["type"] == "ls":
+            self.handle_new_client(message["CID"], request.remote_addr, message["payload"]["files"])
+
+        # A client sends a file request, this is the only other possibility
+        else:
+            if message["payload"]["type"] != "request":
+                return # TODO return an error code or something
+
+            self.handle_file_request(message["CID"], message["payload"]["file"])
 
 
-def send_filestore(cid):
-    """Clients need the list of all files available in the network
-    (statement of the project). Therefore this function has to be
-    called at some point to share that list of files with the clients.
+    def handle_new_client(self, cid, ip, files):
+        """
+        Registers a new client by remembering the CID and IP of the exit node,
+        and send back the list of available files.
+        """
+        # Add the IP address
+        self.peers[cid] == ip
 
-    """
-    # send files to cid.
-    pass
+        # Add the list of files
+        for file in files:
+            self.files[file["name"]] = cid
 
+        # Send back the list of files
+        response = {
+            "CID": cid,
+            "payload": {
+                "type": "ls",
+                "files": list(self.files.keys())
+            }
+        }
+        requests.post(ip, data=response)
 
-@app.route("/", methods=['POST'])
-def index2():
-    return "is this route necessary ?"
+    def handle_file_request(self, request_client_cid, file):
+        """
+        Checks availability of the requested file and creates a bridge if
+        available.
+        """
+        if file not in self.files:
+            return # TODO return an error code or something
 
-@app.route("/", methods=['GET'])
+        request_client_ip = self.peers[request_client_cid]
 
+        # Find the CID and IP of the client owning the requested file
+        owning_client_cid = self.files[file]
+        owning_client_ip = self.peers[owning_client_cid]
+
+        # Create the CID and FSID for this bridge
+        bridge_cid = generate_bytes(cid_size)
+        fsid = self.fsid_counter
+        self.fsid_counter += 1
+
+        # Send a message to the node at the start of the bridge
+        make_bridge_message = {
+            "type": "make_bridge",
+            "bridge_CID": bridge_cid,
+            "to": request_client_ip,
+            "FSID": fsid
+        }
+        # Send on the control channel of the node
+        requests.post(owning_client_IP + "/control/", data=make_bridge_message)
+
+        # Send a message to the node at the end of the bridge
+        receive_bridge_message = {
+            "type": "receive_bridge",
+            "CID": request_client_cid,
+            "bridge_CID": bridge_cid
+        }
+        # Send on the control channel of the node
+        requests.post(request_client_ip + "/control/", data=receive_bridge_message)
+
+        # Send a message to the client, asking he/she to send the file
+        request_message = {
+            "CID": owning_client_CID,
+            "payload": {
+                "type": "request",
+                "file": file,
+                "FSID": fsid
+            }
+        }
+        requests.post(request_client_ip, data=request_message)
+
+tracker = Tracker()
+
+@tracker.route("/", methods=['POST'])
+def main_handler():
+    message = request.get_json()
+    tracker.handle_message(message)
+
+@tracker.route("/", methods=['GET'])
 def index():
     # Process list of files a client has
     return render_template("index.html",
                            data={"file_list": list(files.keys()),
                                  "peers": peers})
 
-@app.route("/announce", methods=['POST'])
-def announce():
-    """Gets list of files from some client and updates table accordingly.
-
-    """
-    pass
-
-@app.route("/request", methods=['POST'])
-def request():
-    """Gets the name of the file wanted by some peer and check
-    availability
-
-    """
-    pass
-
-
-app.run(host='0.0.0.0')
+tracker.run(host='0.0.0.0')


### PR DESCRIPTION
I implemented basic functions of the tracker. I could locally test the `handle_new_client` method by running in a shell

```bash
curl -H 'Content-Type: application/json' -d '{"CID": 42, "payload":{"type":"ls","files":[{"name":"Hi"},{"name":"There!"}]}}' http://0.0.0.0:5000
```
And the two files indeed showed up in the browser at `0.0.0.0:5000` with localhost as IP and the CID 
42 :+1: 
I just had to comment out the response from the tracker with the list of files in order to do this test.

The code in the class Tracker could be used to patch Node and Client, since having the routes inside of the class is much cleaner.